### PR TITLE
Adds a 404 error page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import "./App.scss";
 import { Route, Routes } from "react-router-dom";
 import { Navbar, Footer } from "./components";
-import Home from "./sections";
+import Home from "./sections/Home";
+import WildPage from "./sections/WildPage";
 
 function App() {
   return (
@@ -10,7 +11,7 @@ function App() {
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/services" element={<Home />} />
+        <Route path="*" element={<WildPage />} />
       </Routes>
       <Footer />
     </>

--- a/src/sections/Home/index.ts
+++ b/src/sections/Home/index.ts
@@ -1,0 +1,3 @@
+import Home from "./Home";
+
+export default Home;

--- a/src/sections/WildPage/WildPage.scss
+++ b/src/sections/WildPage/WildPage.scss
@@ -1,0 +1,18 @@
+.WildPage {
+  height: 100vh;
+  padding: 0 10%;
+  color: white;
+}
+
+.Title {
+  padding-top: 30vh;
+  text-align: center;
+}
+
+.Link {
+  color: white;
+
+  &:hover {
+    color: var(--primary-light);
+  }
+}

--- a/src/sections/WildPage/WildPage.tsx
+++ b/src/sections/WildPage/WildPage.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Paragraph, Subtitle } from "../../components";
+
+import "./WildPage.scss";
+
+function WildPage() {
+  return (
+    <div className="WildPage">
+      <div className="Title">
+        <Subtitle>404 Error Page Not Found</Subtitle>
+        <Paragraph>
+          Oh dear, someone must be punished for this horrendous mistake. Don't
+          worry, we're firing our web development team as we speak 😡
+        </Paragraph>
+        <p className="Paragraph">
+          In the meantime, feel free to return to our{" "}
+          <Link to="/" className="Link">
+            home page.
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default WildPage;

--- a/src/sections/WildPage/index.ts
+++ b/src/sections/WildPage/index.ts
@@ -1,0 +1,3 @@
+import WildPage from "./WildPage";
+
+export default WildPage;

--- a/src/sections/index.ts
+++ b/src/sections/index.ts
@@ -1,3 +1,0 @@
-import Home from "./Home/Home";
-
-export default Home;


### PR DESCRIPTION
Closes #36.

Adds a 404 error page. Since we didn't receive any UX for this, I only put the bare minimum on the page.

<img width="1702" alt="Screen Shot 2022-09-21 at 9 18 19 PM" src="https://user-images.githubusercontent.com/42760127/191637346-11f63a82-07e3-415f-8ac9-7ac879d5cd86.png">

**Testing Instructions**

Open the [netlify preview](https://deploy-preview-43--elegant-fairy-2ff919.netlify.app/). Type in a random url like `https://deploy-preview-43--elegant-fairy-2ff919.netlify.app/randompage`. You should be taken to the 404 page. Clicking on `homepage` returns you to `Home`.