### PR TITLE
Add padding to VIP card

### DIFF
--- a/src/sections/Home/components/PricingCard/PricingCard.scss
+++ b/src/sections/Home/components/PricingCard/PricingCard.scss
@@ -85,7 +85,7 @@
       #9353ff 74%
     ),
     linear-gradient(180deg, #8c8673 0%, #b4a985 60%, #9353ff 100%);
-  padding: 50px 0;
+  padding: 50px 8px;
 
   p {
     text-align: center;


### PR DESCRIPTION
Closes #35.

The basic card has `padding: 8px`. I added `8px` to the left and right of the VIP card to match the width of the basic card.