### PR TITLE
Finish layout of team page

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -18,6 +18,7 @@ body {
 
   margin: 0;
   font-family: "Poppins", sans-serif;
+  background: var(--background-dark);
 }
 
 div {

--- a/src/assets/MemberCard.svg
+++ b/src/assets/MemberCard.svg
@@ -1,0 +1,29 @@
+<svg width="1167" height="746" viewBox="0 0 1167 746" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_800_1625)">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H1167V746H40C17.9086 746 0 728.091 0 706V40Z" fill="#9353FF"/>
+<circle cx="127" cy="364" r="279" fill="url(#paint0_radial_800_1625)" fill-opacity="0.4"/>
+<path d="M1175.5 657C1175.5 763.159 1091.83 848.5 989.5 848.5C887.166 848.5 803.5 763.159 803.5 657C803.5 550.841 887.166 465.5 989.5 465.5C1091.83 465.5 1175.5 550.841 1175.5 657Z" fill="url(#paint1_radial_800_1625)" fill-opacity="0.4" stroke="url(#paint2_radial_800_1625)" stroke-width="31"/>
+<ellipse cx="1084" cy="128.5" rx="125" ry="128.5" fill="url(#paint3_radial_800_1625)" fill-opacity="0.3"/>
+</g>
+<defs>
+<radialGradient id="paint0_radial_800_1625" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160.48 5.01997) rotate(90.7759) scale(858.469)">
+<stop stop-color="#DAFF01"/>
+<stop offset="1" stop-color="#DAFF01" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint1_radial_800_1625" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1013.68 390.66) rotate(90.7553) scale(636.925 620.008)">
+<stop stop-color="#DAFF01"/>
+<stop offset="1" stop-color="#DAFF01" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint2_radial_800_1625" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1005 578.5) rotate(93.1076) scale(285.92 278.324)">
+<stop stop-color="#DAFF01"/>
+<stop offset="0.484375" stop-color="#DAFF01" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint3_radial_800_1625" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1099 -36.8367) rotate(90.7548) scale(395.386 384.621)">
+<stop stop-color="#DAFF01"/>
+<stop offset="1" stop-color="#DAFF01" stop-opacity="0"/>
+</radialGradient>
+<clipPath id="clip0_800_1625">
+<rect width="1167" height="746" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/sections/Home/Home.scss
+++ b/src/sections/Home/Home.scss
@@ -1,7 +1,3 @@
-body {
-  background: var(--background-dark);
-}
-
 .Home {
   background: radial-gradient(
       farthest-side at bottom left,

--- a/src/sections/Team/MemberInfo.tsx
+++ b/src/sections/Team/MemberInfo.tsx
@@ -1,0 +1,168 @@
+import { UniYear, CusecExec } from "../../types";
+
+type CusecTeam = {
+  name: string;
+  members: CusecExec[];
+};
+
+export const chairs: CusecTeam = {
+  name: "Chairs",
+  members: [
+    {
+      name: "Charmaine Yung",
+      uni: "University of Toronto",
+      year: UniYear.Fifth,
+      major: "Computer Science",
+      quote:
+        "I have a Google Maps list of food places to try. I have over 200 places but they're mostly on the east coast which is a problem. Please approach me at the conference (or DM me) and hit me with your favourite restaurants from your city!",
+      fact: "I do fencing with lightsabers (it's an officially recognized weapon of the French Fencing Federation!) on Thursdays, which I learned about from a guy I met on the subway who does it",
+    },
+  ],
+};
+
+export const logistics: CusecTeam = {
+  name: "Logistics Team",
+  members: [
+    {
+      name: "Sarah Veloso",
+      uni: "University of Manitoba",
+      year: UniYear.Second,
+      major: "Computer Science and Psychology",
+      quote:
+        "Hello! My name is Sarah. I'm in the second year of my double major in computer science and psychology at the University of Manitoba. I love trying new things and meeting new people! Just this year, I fished for the very first time, I learned to play the trombone, and I met someone who bore a striking resemblance to bbno$. I'm honoured and excited to help bring CUSEC back to an in-person conference!",
+      fact: "I play Call of Duty with bots set to rookie level.",
+    },
+    {
+      name: "Denys Popov",
+      uni: "University of Manitoba",
+      year: UniYear.Forth,
+      major: "Computer Science",
+      quote:
+        "Hello everyone, this is going to be my second CUSEC and the first one in-person. I am a 4th year computer science student at University of Manitoba. I absolutely love basketball, boxing, playing the guitar, biking and, of course, coding.",
+      fact: "Too difficult. No fun. No facts.",
+    },
+  ],
+};
+
+export const sponsorship: CusecTeam = {
+  name: "Sponsorship Team",
+  members: [
+    {
+      name: "",
+      uni: "",
+      year: UniYear.First,
+      major: "",
+      quote: "",
+      fact: "",
+    },
+  ],
+};
+
+export const speakers: CusecTeam = {
+  name: "Speakers Team",
+  members: [
+    {
+      name: "",
+      uni: "",
+      year: UniYear.First,
+      major: "",
+      quote: "",
+      fact: "",
+    },
+  ],
+};
+
+export const technology: CusecTeam = {
+  name: "Technology Team",
+  members: [
+    {
+      name: "Melissa Lin",
+      uni: "Stony Brook University",
+      year: UniYear.Forth,
+      major: "Psychology",
+      quote:
+        "I love sushi, cats, and fashion. Some of my other hobbies is playing Valorant with friends, building keyboards, or working on cool design projects!",
+      fact: "My teacher's chicken jumped and sat on my shoulder once",
+    },
+    {
+      name: "Danielle D'Souza",
+      uni: "University of Waterloo",
+      year: UniYear.Third,
+      major: "Computer Science",
+      quote:
+        "Hey! My name is Danielle, and I'm just a girl in love with dance and code - lots of it! School, work, and dance take up most of my hours, but in my free time you can catch me hiking, watching anime, or pulling irresponsible all-nighters with my friends on campus!",
+      fact: "I'm part of a competitive university hip hop dance team.",
+    },
+  ],
+};
+
+export const events: CusecTeam = {
+  name: "Events Team",
+  members: [
+    {
+      name: "",
+      uni: "",
+      year: UniYear.First,
+      major: "",
+      quote: "",
+      fact: "",
+    },
+  ],
+};
+
+export const promotions: CusecTeam = {
+  name: "Promotions Team",
+  members: [
+    {
+      name: "Jordon Hong",
+      uni: "University of Manitoba",
+      year: UniYear.Second,
+      major: "Computer Science",
+      quote:
+        "Hey everybody! I'm Jordon (sounds like Jordan), your friendly neighbourhood promo director. I'm a second year at the University of Manitoba majoring in computer science and minoring in linguistics. I love D&D, Netflix, and listening to music (especially indie, R&B, and kpop). Second time delegate, first time organizer, so I'm very excited to meet new people. If you see me in at the venue and want to chat about music, code, whatever, don't be shy say hi!",
+      fact: "I have a Duolingo streak of 272 in Mandarin and Korean (as of Sept 29) but can barely speak either lol",
+    },
+  ],
+};
+
+export const headDelegates: CusecTeam = {
+  name: "Head Delegates",
+  members: [
+    {
+      name: "Yasin Elmi",
+      uni: "University of Ottawa",
+      year: UniYear.Third,
+      major: "Computer Science",
+      quote:
+        "Hello my name is Yasin Elmi, I am a third year computer science major and I work part-time for the University of Ottawa as an engineering mentor. Something about myself is that I love to learn and interact with others as well as playing video games, basketball and volleyball. I can't wait to meet and learn from so many people at CUSEC 2023!",
+      fact: "I lived in africa for 5 years of my life",
+    },
+    {
+      name: "Ara Nicole Santos",
+      uni: "University of Manitoba",
+      year: UniYear.Second,
+      major: "Computer Science",
+      quote:
+        "Hi everyone, I’m Ara! I’m the Head Delegate for University of Manitoba. I’m so excited to be a part of CUSEC 2023 as this is my first time joining its team and attending it! I’m currently in my second year of university studying Computer Science and Psychology. My hobbies include reading books and listening to music, especially indie pop. I LOVE to eat chocolate chip cookies and drink bubble tea! I’m so happy to be a part of such a supportive team, and I can’t wait to share with y’all what we have planned for the year !!",
+      fact: "! was born with a tooth",
+    },
+    {
+      name: "Mohammad Zafar",
+      uni: "University of Regina",
+      year: UniYear.Second,
+      major: "Software Engineering",
+      quote:
+        "Hey! My name is Mohammad and I'm in my second year of Software Engineering at the University of Regina. I will also be representing Regina as Head Delegate! I love messing around with carpentry and graphic design. See you at CUSEC!",
+      fact: "I can speak 4 languages",
+    },
+    {
+      name: "Abdul-Hakim Skaik",
+      uni: "Concordia University",
+      year: UniYear.Second,
+      major: "Software Engineering ",
+      quote:
+        "Hello everyone! My name is Hakim and I'm a second year Software Engineer @ Concordia. This is my first year @ CUSEC and I'm excited to be the head delegate of Concordia. I consider myself to be a cool person...or at least I'd like to think so, that means feel free to connect with me and have a coffee chat so we can be cool together. If there's anything I love doing is meeting new people from different backgrounds. I can't wait for CUSEC 2023 to meet more cool people Ü .",
+      fact: "I don't sleep without tiktok",
+    },
+  ],
+};

--- a/src/sections/Team/Team.scss
+++ b/src/sections/Team/Team.scss
@@ -1,8 +1,15 @@
 .Team {
+  background: radial-gradient(
+      farthest-side at bottom left,
+      #9651fe38,
+      transparent
+    ),
+    radial-gradient(farthest-corner at bottom right, #9651fe38, transparent);
   color: white;
-  background-color: rgb(18, 2, 18);
+  padding: 0 18%;
 
   ul {
+    padding: 0;
     font-size: 35px;
     list-style: none;
   }

--- a/src/sections/Team/Team.scss
+++ b/src/sections/Team/Team.scss
@@ -6,9 +6,9 @@
     ),
     radial-gradient(farthest-corner at bottom right, #9651fe38, transparent);
   color: white;
-  padding: 0 18%;
+  padding: 10% 18% 0 18%;
 
-  ul {
+  .TeamList {
     padding: 0;
     font-size: 35px;
     list-style: none;

--- a/src/sections/Team/Team.tsx
+++ b/src/sections/Team/Team.tsx
@@ -1,33 +1,44 @@
-import "./Team.scss";
 import Paragraph from "../../components/Paragraph/Paragraph";
 import Subtitle from "../../components/Subtitle/Subtitle";
 import ExpandableDiv from "./components/ExpandableDiv";
-
-const members: string[] = [
-  "Chairs",
-  "Logistics Team",
-  "Sponsorship Team",
-  "Speakers Team",
-  "Technology Team",
-  "Events Team",
-  "Promotions Team",
-];
+import {
+  chairs,
+  logistics,
+  sponsorship,
+  speakers,
+  technology,
+  events,
+  promotions,
+  headDelegates,
+} from "./MemberInfo";
+import "./Team.scss";
 
 function Team() {
   return (
     <div className="Team">
-      <div className="Title">
-        <Subtitle>Meet The Team!</Subtitle>
-        <Paragraph>
-          Click on the drop tabs to learn more about the people who make up the
-          different parts of CUSEC.
-        </Paragraph>
-        <div className="Category">
-          <ul>
-            {members.map((member) => (
-              <ExpandableDiv>{member}</ExpandableDiv>
-            ))}
-          </ul>
+      <div className="Section">
+        <div className="CenterText">
+          <Subtitle>Meet The Team!</Subtitle>
+          <Paragraph>
+            Click on the drop tabs to learn more about the people who make up
+            the different parts of CUSEC.
+          </Paragraph>
+        </div>
+        <div className="TeamList">
+          <ExpandableDiv role={chairs.name} members={chairs.members} />
+          <ExpandableDiv role={logistics.name} members={logistics.members} />
+          <ExpandableDiv
+            role={sponsorship.name}
+            members={sponsorship.members}
+          />
+          <ExpandableDiv role={speakers.name} members={speakers.members} />
+          <ExpandableDiv role={technology.name} members={technology.members} />
+          <ExpandableDiv role={events.name} members={events.members} />
+          <ExpandableDiv role={promotions.name} members={promotions.members} />
+          <ExpandableDiv
+            role={headDelegates.name}
+            members={headDelegates.members}
+          />
         </div>
       </div>
     </div>

--- a/src/sections/Team/components/ExpandableDiv.scss
+++ b/src/sections/Team/components/ExpandableDiv.scss
@@ -74,3 +74,11 @@
     text-align: center;
   }
 }
+
+@media screen and (max-width: 480px) {
+  .ExpandableDiv {
+    .CardContent {
+      display: block;
+    }
+  }
+}

--- a/src/sections/Team/components/ExpandableDiv.scss
+++ b/src/sections/Team/components/ExpandableDiv.scss
@@ -1,5 +1,5 @@
 .RoundedList {
-  margin: 0.7em 2.5em 1em;
+  margin: 0.7em 0;
   background: #ffffff;
   position: relative;
   border-radius: 40px 0px 0px 40px;

--- a/src/sections/Team/components/ExpandableDiv.scss
+++ b/src/sections/Team/components/ExpandableDiv.scss
@@ -1,12 +1,27 @@
-.RoundedList {
+.ExpandableDiv {
+  overflow: hidden;
+
+  .fa-circle {
+    padding: 0 10px;
+  }
+
+  .Temporary {
+    font-size: 200px;
+    padding: 0 30px;
+    display: flex;
+    align-items: center;
+    height: 100%;
+  }
+}
+
+.Heading {
+  display: flex;
   margin: 0.7em 0;
   background: #ffffff;
-  position: relative;
+  align-items: center;
   border-radius: 40px 0px 0px 40px;
   color: #000000;
-  text-align: left;
-  display: flex;
-  align-items: center;
+  cursor: pointer;
 }
 
 .PlusIcon {
@@ -21,6 +36,41 @@
   font: 32px Arial, sans-serif;
 }
 
-.Position {
-  font-size: 70%;
+.MemberCards {
+  margin-top: -0.7em;
+  transition: height 0.2s ease-in-out;
+}
+
+.CardContent {
+  background-image: url(../../../assets/MemberCard.svg);
+  padding: 20px;
+  min-height: 250px;
+  font-size: var(--font-standard);
+  display: grid;
+  grid-template-areas:
+    "photo photo photo main main main"
+    "footer footer footer footer footer footer";
+
+  .Photo {
+    grid-area: photo;
+  }
+
+  .MemberInfo {
+    grid-area: main;
+
+    .Name {
+      font-weight: bold;
+      font-size: var(--font-subheading);
+      margin-bottom: 0;
+    }
+
+    .University {
+      margin-top: 0;
+    }
+  }
+
+  .Circles {
+    grid-area: footer;
+    text-align: center;
+  }
 }

--- a/src/sections/Team/components/ExpandableDiv.scss
+++ b/src/sections/Team/components/ExpandableDiv.scss
@@ -43,6 +43,7 @@
 
 .CardContent {
   background-image: url(../../../assets/MemberCard.svg);
+  border-radius: 0 0 0 40px;
   padding: 20px;
   min-height: 250px;
   font-size: var(--font-standard);

--- a/src/sections/Team/components/ExpandableDiv.tsx
+++ b/src/sections/Team/components/ExpandableDiv.tsx
@@ -66,7 +66,7 @@ const ExpandableDiv = ({ role, members, children }: Props) => {
       <div className="MemberCards" style={{ height }}>
         <div ref={ref}>
           <div className="CardContent">
-            <div className="Photo">
+            <div className="Photo HideOnMobile">
               <i className="fa-solid fa-image Temporary"></i>
             </div>
             <div className="MemberInfo">

--- a/src/sections/Team/components/ExpandableDiv.tsx
+++ b/src/sections/Team/components/ExpandableDiv.tsx
@@ -1,22 +1,92 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { Paragraph } from "../../../components";
+import { CusecExec } from "../../../types";
 import "./ExpandableDiv.scss";
-import Paragraph from "../../../components/Paragraph/Paragraph";
 
 interface Props {
-  children: string;
+  role: string;
+  members: CusecExec[];
+  children?: string;
 }
 
-const ExpandableDiv = ({ children }: Props) => {
+const ExpandableDiv = ({ role, members, children }: Props) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const [open, setOpen] = useState(false);
+  const [height, setHeight] = useState<number | undefined>(
+    open ? undefined : 0
+  );
+  const [currentMember, setCurrentMember] = useState(members[0]);
+
+  const handleFilterOpening = () => {
+    setOpen(!open);
+  };
+
+  useEffect(() => {
+    if (!height || !open || !ref.current) {
+      return;
+    }
+
+    const observer = new ResizeObserver((card) => {
+      setHeight(card[0].contentRect.height);
+    });
+
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [height, open]);
+
+  useEffect(() => {
+    if (open && ref.current) {
+      setHeight(ref.current.getBoundingClientRect().height);
+    } else {
+      setHeight(0);
+    }
+  }, [open]);
+
+  const circles = members.map((member) => (
+    <i
+      className={`fa-solid fa-circle ${
+        member === currentMember ? "Highlight" : ""
+      }`}
+      onClick={() => setCurrentMember(member)}
+    ></i>
+  ));
+
   return (
-    <li className="RoundedList">
-      <i className="fa-solid fa-plus PlusIcon"></i>
-      <Paragraph inline className="Position">
-        {children}
-      </Paragraph>
-    </li>
+    <div className="ExpandableDiv">
+      <div>
+        <div className="Heading" onClick={handleFilterOpening}>
+          <i className="fa-solid fa-plus PlusIcon"></i>
+          <Paragraph inline>{role}</Paragraph>
+        </div>
+      </div>
+      <div className="MemberCards" style={{ height }}>
+        <div ref={ref}>
+          <div className="CardContent">
+            <div className="Photo">
+              <i className="fa-solid fa-image Temporary"></i>
+            </div>
+            <div className="MemberInfo">
+              <p className="Name Highlight">{currentMember.name}</p>
+              <p className="University">{currentMember.uni}</p>
+              <p>
+                Year: {currentMember.year} | {currentMember.major}
+              </p>
+              <p>"{currentMember.quote}"</p>
+              <p>
+                <span className="Highlight">Fun Fact:</span>{" "}
+                {currentMember.fact}
+              </p>
+            </div>
+            <div className="Circles">{circles}</div>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 };
-
-
 
 export default ExpandableDiv;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -8,3 +8,20 @@ export type FAQType = {
   question: string;
   answer: string;
 };
+
+export enum UniYear {
+  First = "1st",
+  Second = "2nd",
+  Third = "3rd",
+  Forth = "4th",
+  Fifth = "5th",
+}
+
+export type CusecExec = {
+  name: string;
+  uni: string;
+  year: UniYear;
+  major: string;
+  quote: string;
+  fact: string;
+};


### PR DESCRIPTION
Closes #57.

https://user-images.githubusercontent.com/42760127/193660717-901f78be-0916-4aad-9ee8-1e81759f2a00.mov

Adds the `on click` handler and information for all members who have currently submitted the team member info form. I haven't added the pictures yet because I want to see the format everyone sends the pictures in. Let's add the pictures and the rest of the members in a follow up PR. (I'll create a ticket.)

Ahhh I know there are a couple differences between the figma and this but lemme make a case for my changes!

1. Replacing the `role` under the name with `university
**Figma**
<img width="562" alt="Screen Shot 2022-10-03 at 3 21 58 PM" src="https://user-images.githubusercontent.com/42760127/193660962-f3edb94a-6fe4-49ea-a319-b339d7956e8e.png">

**Mine**
<img width="611" alt="Screen Shot 2022-10-03 at 3 24 02 PM" src="https://user-images.githubusercontent.com/42760127/193661340-4cd268db-949b-49ac-bf52-441e7e1a3b52.png">

It seemed redundant to include the role twice - everyone under the `Chair` tab is a chair! So instead, I figured we should offer new information like the person's university.

2. Rounded corner instead of sharp corner.

**Figma**
<img width="126" alt="Screen Shot 2022-10-03 at 3 23 25 PM" src="https://user-images.githubusercontent.com/42760127/193661225-e399dd94-86a8-4077-a1e6-6228527078ae.png">

**Mine**
<img width="121" alt="Screen Shot 2022-10-03 at 3 24 18 PM" src="https://user-images.githubusercontent.com/42760127/193661394-4da9e626-6edd-4fcc-9be9-15c8bad2d64c.png">

Okay admittedly I don't have a defense for this. There was just too much custom CSS so I figured I would leave it like this for now - let's get feedback from the team - and _then_ we add all the extra CSS if enough people think it's worth it! It's not actually that bad - just some negative margins/paddings, but enough to make me want to leave it like this for this PR.