### PR TITLE
Add policy and term pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import { Navbar, Footer } from "./components";
 import Home from "./sections/Home";
 import Team from "./sections/Team/Team";
 import WildPage from "./sections/WildPage";
+import CodeOfConduct from "./sections/CodeOfConduct/CodeOfConduct";
+import PrivacyPolicy from "./sections/PrivacyPolicy/PrivacyPolicy";
+import TermsOfUse from "./sections/TermsOfUse/TermsOfUse";
 
 function App() {
   const navigate = useNavigate();
@@ -33,6 +36,9 @@ function App() {
       <Routes>
         <Route path="/" element={<Home faqRef={faqSection} />} />
         <Route path="/team" element={<Team />} />
+        <Route path="/codeofconduct" element={<CodeOfConduct />} />
+        <Route path="/privacy" element={<PrivacyPolicy />} />
+        <Route path="/terms" element={<TermsOfUse />} />
         <Route path="*" element={<WildPage />} />
       </Routes>
       <Footer />

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,8 +7,8 @@ import "./Footer.scss";
 const Footer = () => {
   const links = [
     { name: "Privacy", link: "/privacy" },
-    { name: "Terms", link: "/terms" },
-    { name: "Contact Us", link: "/contact" },
+    { name: "Code of Conduct", link: "/codeofconduct" },
+    { name: "Terms of Use", link: "/terms" },
   ];
 
   const footerLinks = links.map(({ link, name }) => {

--- a/src/sections/CodeOfConduct/CodeOfConduct.scss
+++ b/src/sections/CodeOfConduct/CodeOfConduct.scss
@@ -1,0 +1,11 @@
+.CodeOfConduct {
+  background: radial-gradient(
+      farthest-side at bottom left,
+      #9651fe38,
+      transparent
+    ),
+    radial-gradient(farthest-corner at bottom right, #9651fe38, transparent);
+  color: white;
+  padding: 10% 18% 10% 18%;
+  font-size: var(--font-standard);
+}

--- a/src/sections/CodeOfConduct/CodeOfConduct.tsx
+++ b/src/sections/CodeOfConduct/CodeOfConduct.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { Subtitle } from "../../components";
+import "./CodeOfConduct.scss";
+
+function CodeOfConduct() {
+  return (
+    <div className="CodeOfConduct">
+      <div className="CenterText">
+        <Subtitle>Code of Conduct</Subtitle>
+      </div>
+      <p>
+        All participants of CUSEC are expected to abide by our Code of Conduct,
+        both online and during in-person events that are hosted and/or
+        associated with CUSEC.
+      </p>
+      <p className="Bold">The Pledge</p>
+      <p>
+        In the interest of fostering an open and welcoming environment, we
+        pledge to make participation in our project and our community a
+        harassment-free experience for everyone, regardless of age, body size,
+        disability, ethnicity, gender identity and expression, level of
+        experience, nationality, personal appearance, race, religion, or sexual
+        identity and orientation.
+      </p>
+      <p className="Bold">The Standards</p>
+      <p>
+        Examples of behaviour that contributes to creating a positive
+        environment include:
+      </p>
+      <ul>
+        <li>Using welcoming and inclusive language.</li>
+        <li>Being respectful of differing viewpoints and experiences.</li>
+        <li>Gracefully accepting constructive criticism.</li>
+        <li>
+          Referring to people by their preferred pronouns and using
+          gender-neutral pronouns when uncertain.
+        </li>
+      </ul>
+
+      <p>Examples of unacceptable behaviour by participants include:</p>
+      <ul>
+        <li>
+          Trolling, insulting/derogatory comments, public or private harassment.
+        </li>
+        <li>
+          Publishing others' private information, such as a physical or
+          electronic address, without explicit permission.
+        </li>
+
+        <li>
+          Not being respectful to reasonable communication boundaries, such as
+          'leave me alone,' 'go away,' or 'I’m not discussing this with you.'
+        </li>
+
+        <li>
+          The usage of sexualized language or imagery and unwelcome sexual
+          attention or advances.
+        </li>
+
+        <li>Swearing, usage of strong or disturbing language.</li>
+
+        <li>
+          Demonstrating the graphics or any other content you know may be
+          considered disturbing.
+        </li>
+
+        <li>Starting and/or participating in arguments related to politics.</li>
+
+        <li>
+          Assuming or promoting any kind of inequality including but not limited
+          to: age, body size, disability, ethnicity, gender identity and
+          expression, nationality and race, personal appearance, religion, or
+          sexual identity and orientation.
+        </li>
+
+        <li>Drug promotion of any kind.</li>
+
+        <li>Attacking personal tastes.</li>
+
+        <li>
+          Other conduct which you know could reasonably be considered
+          inappropriate in a professional setting.
+        </li>
+      </ul>
+
+      <p className="Bold">Enforcement</p>
+
+      <p>
+        Violations of the Code of Conduct may be reported by sending an email to
+        incidents@cusec.net. All reports will be reviewed and investigated and
+        will result in a response that is deemed necessary and appropriate to
+        the circumstances. Further details of specific enforcement policies may
+        be posted separately. We hold the right and responsibility to remove
+        comments or other contributions that are not aligned to this Code of
+        Conduct, or to ban temporarily or permanently any members for other
+        behaviours that they deem inappropriate, threatening, offensive, or
+        harmful.
+      </p>
+    </div>
+  );
+}
+
+export default CodeOfConduct;

--- a/src/sections/PrivacyPolicy/PrivacyPolicy.scss
+++ b/src/sections/PrivacyPolicy/PrivacyPolicy.scss
@@ -1,0 +1,11 @@
+.PrivacyPolicy {
+  background: radial-gradient(
+      farthest-side at bottom left,
+      #9651fe38,
+      transparent
+    ),
+    radial-gradient(farthest-corner at bottom right, #9651fe38, transparent);
+  color: white;
+  padding: 10% 18% 10% 18%;
+  font-size: var(--font-standard);
+}

--- a/src/sections/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/src/sections/PrivacyPolicy/PrivacyPolicy.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Subtitle } from "../../components";
+import "./PrivacyPolicy.scss";
+
+function PrivacyPolicy() {
+  return (
+    <div className="PrivacyPolicy">
+      <div className="CenterText">
+        <Subtitle>Privacy Policy</Subtitle>
+      </div>
+      <p>
+        Your privacy is important to us. It is CUSEC's policy to respect your
+        privacy regarding any information we may collect from you across our
+        website, https://2021.cusec.net, and other sites we own and operate.
+      </p>
+
+      <p>
+        We only ask for personal information when we truly need it to provide a
+        service to you. We collect it by fair and lawful means, with your
+        knowledge and consent. We also let you know why we’re collecting it and
+        how it will be used.
+      </p>
+      <p>
+        We only retain collected information for as long as necessary to provide
+        you with your requested service. What data we store, we’ll protect
+        within commercially acceptable means to prevent loss and theft, as well
+        as unauthorized access, disclosure, copying, use or modification.
+      </p>
+
+      <p>
+        We don’t share any personally identifying information publicly or with
+        third-parties, except when required to by law.
+      </p>
+
+      <p>
+        Our website may link to external sites that are not operated by us.
+        Please be aware that we have no control over the content and practices
+        of these sites, and cannot accept responsibility or liability for their
+        respective privacy policies.
+      </p>
+
+      <p>
+        You are free to refuse our request for your personal information, with
+        the understanding that we may be unable to provide you with some of your
+        desired services.
+      </p>
+
+      <p>
+        Your continued use of our website will be regarded as acceptance of our
+        practices around privacy and personal information. If you have any
+        questions about how we handle user data and personal information, feel
+        free to contact us.
+      </p>
+
+      <p>This policy is effective as of 15 September 2020.</p>
+    </div>
+  );
+}
+
+export default PrivacyPolicy;

--- a/src/sections/TermsOfUse/TermsOfUse.scss
+++ b/src/sections/TermsOfUse/TermsOfUse.scss
@@ -1,0 +1,11 @@
+.TermsOfUse {
+  background: radial-gradient(
+      farthest-side at bottom left,
+      #9651fe38,
+      transparent
+    ),
+    radial-gradient(farthest-corner at bottom right, #9651fe38, transparent);
+  color: white;
+  padding: 10% 18% 10% 18%;
+  font-size: var(--font-standard);
+}

--- a/src/sections/TermsOfUse/TermsOfUse.tsx
+++ b/src/sections/TermsOfUse/TermsOfUse.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { Subtitle } from "../../components";
+import "./TermsOfUse.scss";
+
+function TermsOfUse() {
+  return (
+    <div className="TermsOfUse">
+      <div className="CenterText">
+        <Subtitle>Terms Of Use</Subtitle>
+      </div>
+      <ol>
+        <li>
+          <p className="Bold">Terms</p>
+          <p>
+            By accessing this website, you are agreeing to be bound by these
+            terms of service, all applicable laws and regulations, and agree
+            that you are responsible for compliance with any applicable local
+            laws. If you do not agree with any of these terms, you are
+            prohibited from using or accessing this site. The materials
+            contained in this website are protected by applicable copyright and
+            trademark law.
+          </p>
+        </li>
+        <li>
+          <p className="Bold">Use License</p>
+          <p>
+            Permission is granted to temporarily download one copy of the
+            materials (information or software) on CUSEC's website for personal,
+            non-commercial transitory viewing only. This is the grant of a
+            license, not a transfer of title, and under this license you may
+            not:
+          </p>
+          <ul>
+            <li>modify or copy the materials;</li>
+            <li>
+              use the materials for any commercial purpose, or for any public
+              display (commercial or non-commercial);
+            </li>
+            <li>
+              attempt to decompile or reverse engineer any software contained on
+              CUSEC's website;
+            </li>
+            <li>
+              remove any copyright or other proprietary notations from the
+              materials; or
+            </li>
+            <li>
+              transfer the materials to another person or "mirror" the materials
+              on any other server.
+            </li>
+          </ul>
+          <p>
+            This license shall automatically terminate if you violate any of
+            these restrictions and may be terminated by CUSEC at any time. Upon
+            terminating your viewing of these materials or upon the termination
+            of this license, you must destroy any downloaded materials in your
+            possession whether in electronic or printed format.
+          </p>
+        </li>
+        <li>
+          <p className="Bold">Disclaimer</p>
+          <p>
+            The materials on CUSEC's website are provided on an 'as is' basis.
+            CUSEC makes no warranties, expressed or implied, and hereby
+            disclaims and negates all other warranties including, without
+            limitation, implied warranties or conditions of merchantability,
+            fitness for a particular purpose, or non-infringement of
+            intellectual property or other violation of rights. Further, CUSEC
+            does not warrant or make any representations concerning the
+            accuracy, likely results, or reliability of the use of the materials
+            on its website or otherwise relating to such materials or on any
+            sites linked to this site.
+          </p>
+        </li>
+        <li>
+          <p className="Bold">Limitations</p>
+          <p>
+            In no event shall CUSEC or its suppliers be liable for any damages
+            (including, without limitation, damages for loss of data or profit,
+            or due to business interruption) arising out of the use or inability
+            to use the materials on CUSEC's website, even if CUSEC or a CUSEC
+            authorized representative has been notified orally or in writing of
+            the possibility of such damage. Because some jurisdictions do not
+            allow limitations on implied warranties, or limitations of liability
+            for consequential or incidental damages, these limitations may not
+            apply to you.
+          </p>
+        </li>
+        <li>
+          <p className="Bold">Accuracy of materials</p>
+          <p>
+            The materials appearing on CUSEC's website could include technical,
+            typographical, or photographic errors. CUSEC does not warrant that
+            any of the materials on its website are accurate, complete or
+            current. CUSEC may make changes to the materials contained on its
+            website at any time without notice. However CUSEC does not make any
+            commitment to update the materials.
+          </p>
+        </li>
+        <li>
+          <p className="Bold">Links</p>
+          <p>
+            CUSEC has not reviewed all of the sites linked to its website and is
+            not responsible for the contents of any such linked site. The
+            inclusion of any link does not imply endorsement by CUSEC of the
+            site. Use of any such linked website is at the user's own risk.
+          </p>
+        </li>
+        <li>
+          <p className="Bold">Modifications</p>
+          <p>
+            CUSEC may revise these terms of service for its website at any time
+            without notice. By using this website you are agreeing to be bound
+            by the then current version of these terms of service.
+          </p>
+        </li>
+        <li>
+          <p className="Bold">Governing Law</p>
+          <p>
+            These terms and conditions are governed by and construed in
+            accordance with the laws of Quebec, CA and you irrevocably submit to
+            the exclusive jurisdiction of the courts in that State or location.
+          </p>
+        </li>
+      </ol>
+    </div>
+  );
+}
+
+export default TermsOfUse;


### PR DESCRIPTION
Adds a page/route for 

1. Privacy Policy `/privacy`
2. Terms of Use `/terms`
3. Code of conduct `/codeofconduct`

These links are all in the `Footer`. Note that right now the last link will not show because of some global styles to our lists in the navbar. This should be fixed once our team page merges. If that does not fix it, I'll fix it in a future PR.