### PR TITLE
Add mobile about section

### DIFF
--- a/src/sections/Home/Home.scss
+++ b/src/sections/Home/Home.scss
@@ -197,6 +197,57 @@ body {
   }
 }
 
+.MobileAbout {
+  margin-top: -40%;
+  padding: 20% 0;
+
+  .MobileAboutContent {
+    position: relative;
+
+    .Image {
+      padding-top: 10%;
+    }
+
+    .MobileObjectives {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(0, 0, 0, 0.7);
+      width: 80%;
+      padding: 5%;
+      border-radius: 20px;
+
+      .MobileTitle {
+        font-weight: bold;
+
+        p {
+          margin: 0;
+        }
+      }
+
+      ol {
+        margin: 0;
+
+        li {
+          margin: 10px 0;
+        }
+      }
+    }
+
+    .Circles {
+      position: absolute;
+      bottom: 10px;
+      left: 50%;
+      transform: translate(-50%, -50%);
+
+      .fa-circle {
+        padding: 0 10px;
+      }
+    }
+  }
+}
+
 @media screen and (max-width: 768px) {
   .ImageColumn {
     -ms-flex: 30%;

--- a/src/sections/Home/Home.tsx
+++ b/src/sections/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import VanillaTilt from "vanilla-tilt";
 import {
   Button,
@@ -20,6 +20,8 @@ import "./Home.scss";
 interface Props {
   faqRef: React.RefObject<HTMLDivElement>;
 }
+
+const IMAGES = [learnImage, connectImage, discoverImage];
 
 function Home({ faqRef }: Props) {
   const tilt = useRef<HTMLDivElement>(null);
@@ -53,13 +55,13 @@ function Home({ faqRef }: Props) {
 
     switch (text) {
       case "Learn":
-        image.src = learnImage;
+        image.src = IMAGES[0];
         break;
       case "Connect":
-        image.src = connectImage;
+        image.src = IMAGES[1];
         break;
       case "Discover":
-        image.src = discoverImage;
+        image.src = IMAGES[2];
         break;
     }
   };
@@ -69,6 +71,16 @@ function Home({ faqRef }: Props) {
 
     VanillaTilt.init(tilt.current);
   }, []);
+
+  const images = [learnImage, connectImage, discoverImage];
+  const [currentImg, setCurrentImg] = useState(IMAGES[0]);
+
+  const circles = IMAGES.map((img) => (
+    <i
+      className={`fa-solid fa-circle ${img === currentImg ? "Highlight" : ""}`}
+      onClick={() => setCurrentImg(img)}
+    ></i>
+  ));
 
   return (
     <div className="Home">
@@ -117,7 +129,7 @@ function Home({ faqRef }: Props) {
           </div>
         </div>
       </div>
-      <div className="Section InlineSection List">
+      <div className="Section InlineSection List HideOnMobile">
         <div className="SectionImage" ref={imageRef}>
           <Image src={learnImage} alt="Learn image" />
         </div>
@@ -147,6 +159,55 @@ function Home({ faqRef }: Props) {
           </ol>
         </div>
       </div>
+      <div className="OnlyShowOnMobile MobileAbout">
+        <div className="CenterText">
+          <Subtitle>What is CUSEC?</Subtitle>
+        </div>
+        <div className="MobileAboutContent">
+          <Image src={currentImg} alt="Learn image" />
+          <div className="MobileObjectives List">
+            <div className="CenterText MobileTitle">
+              <Paragraph>Our Objectives</Paragraph>
+            </div>
+            <ol>
+              <li>
+                <Paragraph
+                  inline
+                  bold
+                  className="Underline"
+                  onHover={hoverText}
+                >
+                  Learn
+                </Paragraph>
+                <Paragraph inline> from world renowned experts</Paragraph>
+              </li>
+              <li>
+                <Paragraph
+                  inline
+                  bold
+                  className="Underline"
+                  onHover={hoverText}
+                >
+                  Connect
+                </Paragraph>
+                <Paragraph inline> with like-minded students</Paragraph>
+              </li>
+              <li>
+                <Paragraph
+                  className="Underline"
+                  inline
+                  bold
+                  onHover={hoverText}
+                >
+                  Discover
+                </Paragraph>
+                <Paragraph inline> opportunities with many companies</Paragraph>
+              </li>
+            </ol>
+          </div>
+          <div className="Circles">{circles}</div>
+        </div>
+      </div>
       <div className="Section InlineSection List HideOnMobile">
         <div className="SectionContent">
           <div className="SectionAssets">
@@ -173,7 +234,7 @@ function Home({ faqRef }: Props) {
           <Image src={natureImg} alt="Nature image" />
         </div>
       </div>
-      <div className="Section">
+      <div className="Section HideOnMobile">
         <div className="AboutSubtitle">
           <Subtitle>What is CUSEC?</Subtitle>
         </div>


### PR DESCRIPTION
Closes #19.

<img width="408" alt="Screen Shot 2022-10-11 at 11 18 50 PM" src="https://user-images.githubusercontent.com/42760127/195242006-cdca9e0c-32dd-45f3-9052-215fee609e74.png">

It doesn't match exactly, but can we merge this for now and do a final polish later? We're getting a little close to the deadline and I'm hoping the site will be fully functional ahead of our team sync on Thursday.

I've created a final polish ticket where we can both add `quality-of-life` improvements (see #67). Added from this ticket is the gradient border and a `Next` button.

### Some Thoughts!

1. I didn't add the `Next` button because it seemed redundant with the three clickable circles. Without the button, this design matches the `Team` page expandable team member cards. I'd like to merge this and get opinions on whether a `Next` button is needed during the team sync.

2. My `opacity` is very different from the design. I didn't notice until right now actually. Do you think we want the text background to be more transparent  or now? 🤔
