### PR TITLE
Hide schedule in navbar

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -27,7 +27,7 @@ const Navbar = ({ onSponsors, onFaq }: Props) => {
 
   const links = [
     { name: "Home", link: "/" },
-    { name: "Schedule", link: "/schedule" },
+    // { name: "Schedule", link: "/schedule" },
     { name: "Sponsors", link: "/sponsors", scrollsTo: onSponsors },
     { name: "Speakers", link: "/speakers" },
     { name: "Team", link: "/team" },

--- a/src/sections/Home/Home.tsx
+++ b/src/sections/Home/Home.tsx
@@ -34,13 +34,15 @@ function Home({ sponsorsRef, faqRef }: Props) {
   const faqs: FAQType[] = [
     {
       id: 1,
-      question: "Q1",
+      question: "When and Where is CUSEC Happening?",
       answer: "A1",
     },
     {
       id: 2,
-      question: "Q2",
-      answer: "A2",
+      question:
+        "Where can I find the conference schedule, speakers & sponsors?",
+      answer:
+        "The schedule will be available on the website soon along with our list of speakers and sponsors! We are working around the clock to create the best conference experience for you, promised.",
     },
     {
       id: 3,


### PR DESCRIPTION
Temporarily removes `Schedule` from the navbar. This also adds an FAQ letter viewers know that the schedule will be provided soon.

Don't worry about the angry ❌! That's just because there's an used variable but I remove that in #70 which should be merged first.