### PR TITLE
Update pricing cards

### DIFF
--- a/src/sections/Home/Home.tsx
+++ b/src/sections/Home/Home.tsx
@@ -309,6 +309,13 @@ function Home({ sponsorsRef, faqRef }: Props) {
       </div>
       <div className="Section">
         <div className="SectionContent">
+          <div className="CenterText">
+            <Subtitle>Join Us at CUSEC 2023!</Subtitle>
+            <Paragraph>
+              Choose plan that works best for you, feel free to contact us for
+              further questions
+            </Paragraph>
+          </div>
           <div className="PricingCards">
             <PricingCard
               title="Basic"

--- a/src/sections/Home/components/PricingCard/PricingCard.scss
+++ b/src/sections/Home/components/PricingCard/PricingCard.scss
@@ -1,32 +1,41 @@
 .PricingCard {
   display: block;
   width: 40%;
-  max-width: 350px;
-  padding: 8px;
+  max-width: 300px;
+  padding: 40px;
   background-color: #ffffff;
   border-radius: 20px;
   color: black;
   margin: 50px 50px 0 0;
   align-self: center;
 
-  h2 {
-    text-align: center;
-    margin-bottom: 0;
+  h1 {
+    margin: 5px 0;
   }
 
   p {
-    text-align: center;
-    color: #a6a6a6;
+    color: var(--background-subdued);
 
     &.HelpText {
-      margin: 0 80px;
+      margin: 0;
     }
   }
 
+  .MostPopular {
+    display: inline-block;
+    position: relative;
+    left: 100%;
+    transform: translateX(-100%);
+    background: rgba(168, 117, 255, 0.3);
+    border-radius: 20px;
+    padding: 5px 16px;
+    color: var(--primary-dark);
+    font-weight: bold;
+  }
+
   .Icon {
-    color: #9353ff;
-    font-size: 20px;
-    justify-self: center;
+    color: #9353ff47;
+    font-size: 25px;
     align-self: center;
   }
 
@@ -37,70 +46,40 @@
 
   .Features {
     display: grid;
-    grid-template-columns: 1fr 80%;
-    margin: 20px 30px 30px 30px;
-    padding: 25px;
-    border-radius: 20px;
-    background-color: #f9fafb;
+    grid-template-columns: 1fr 85%;
   }
 }
 
 .PriceContainer {
-  display: flex;
-  justify-content: center;
+  .PriceContainerContent {
+    height: 100%;
+    width: 100%;
+    position: relative;
 
-  .Wrapper {
-    border-radius: 50%;
-    padding: 2px;
-    background-color: white;
-    color: black;
+    .PriceExtras {
+      font-size: 20px;
+      font-weight: 400;
+      position: absolute;
+      top: 17px;
+    }
 
-    .WrapperContent {
-      height: 100%;
-      width: 100%;
-      text-align: center;
-      position: relative;
-
-      .DollarSign {
-        font-size: 20px;
-        font-weight: 400;
-        position: absolute;
-        top: 17px;
-      }
-
-      .Price {
-        font-size: 45px;
-        font-weight: 600;
-        margin-left: 16px;
-      }
+    .Price {
+      font-size: 45px;
+      font-weight: 600;
+      margin-right: 16px;
     }
   }
 }
 
 .Vip {
   color: white;
-  background-image: radial-gradient(
-      circle at bottom center,
-      transparent 74%,
-      #9353ff 74%
-    ),
-    linear-gradient(180deg, #8c8673 0%, #b4a985 60%, #9353ff 100%);
-  padding: 50px 8px;
+  background-color: #240060;
 
   p {
-    text-align: center;
     color: white;
   }
 
-  .Features {
-    background-color: #ffffff;
-    p {
-      color: black;
-    }
-  }
-
-  .Wrapper {
-    background-color: transparent;
+  .Icon {
     color: white;
   }
 }
@@ -117,17 +96,6 @@
   }
 
   .Vip {
-    background-image: radial-gradient(
-        circle at bottom center,
-        transparent 76%,
-        #9353ff 76%
-      ),
-      linear-gradient(
-        180deg,
-        rgb(140, 134, 115) 0%,
-        rgb(180, 169, 133) 50%,
-        #9353ff 100%
-      );
     padding: 0;
   }
 }

--- a/src/sections/Home/components/PricingCard/PricingCard.tsx
+++ b/src/sections/Home/components/PricingCard/PricingCard.tsx
@@ -25,16 +25,15 @@ const PricingCard = ({ title, helpText, price, features, vip }: Props) => {
 
   return (
     <div className={className}>
-      <h2>{title}</h2>
-      <p className="HelpText">{helpText}</p>
       <div className="PriceContainer">
-        <div className="Wrapper">
-          <div className="WrapperContent">
-            <span className="DollarSign">$</span>
-            <span className="Price">{price}</span>
-          </div>
+        {vip ? <div className="MostPopular">MOST POPULAR</div> : null}
+        <div className="PriceContainerContent">
+          <span className="Price">${price}</span>
+          <span className="PriceExtras">/ person</span>
         </div>
       </div>
+      <h1>{title}</h1>
+      <p className="HelpText">{helpText}</p>
       <div className="Features">{formattedFeatures}</div>
     </div>
   );


### PR DESCRIPTION
Closes #48.

<img width="909" alt="Screen Shot 2022-10-17 at 7 55 51 PM" src="https://user-images.githubusercontent.com/42760127/196304740-1191ce5c-85ba-42e2-9208-4777bf1de360.png">

Note that this is only changing the colours, and adding the `Most Popular` to the `VIP` card. It does not match the desktop view of the figma.

To be honest, I don't entirely know the best way to match that design so I'm adding it as a nice-to-have in #67. Feel free to tackle it if you're up for it!

The checkmarks aren't quite the right design either - I couldn't figure out how to manipulate the font awesome icons. But I think this is sufficient for our prototype for the upcoming team sync!