### PR TITLE
Add navlink to schedule

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -22,6 +22,12 @@ const Navbar = () => {
 
   const links = [
     { name: "Home", link: "/" },
+    {
+      name: "Schedule",
+      link: "",
+      openPage:
+        "https://drive.google.com/file/d/1H7yhYAeNUe15r0R5WV7cgjf0uLmCC1sP/view?usp=sharing",
+    },
     { name: "Sponsors", link: "/sponsors", hashLink: true },
     { name: "Team", link: "/team" },
     { name: "FAQ", link: "/faq", hashLink: true },


### PR DESCRIPTION
Closes #125. 

This solution was suggested in the technology channel:

<img width="465" alt="Screen Shot 2023-01-12 at 7 15 46 AM" src="https://user-images.githubusercontent.com/42760127/212064071-0c6a2e7a-8222-4c75-8f77-1f89d897e635.png">
